### PR TITLE
Make it working on linux

### DIFF
--- a/src/ElectronWorker.js
+++ b/src/ElectronWorker.js
@@ -198,7 +198,8 @@ class ElectronWorker extends EventEmitter {
       childOpts = {
         env: {
           ...env,
-          ELECTRON_WORKER_ID: this.id
+          ELECTRON_WORKER_ID: this.id,
+          DISPLAY: process.env.DISPLAY
         }
       };
 


### PR DESCRIPTION
Passing `DISPLAY: process.env.DISPLAY` to electron envs makes electron-workers and electron-html-to running on linux. Tested on headless ubuntu server 16.04. Also travis seems to be happy with it https://travis-ci.org/pofider/electron-workers

The additional change in test was required to make the tests passing on windows. It was somehow not deterministic and sometimes crashing before I've made the change.
